### PR TITLE
Update resque to non-abandoned new location and use latest stable

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
-	"name": "stojg/silverstripe-resque",
-	"type": "silverstripe-module",
+    "name": "stojg/silverstripe-resque",
+    "type": "silverstripe-module",
     "description": "Wraps around the resque code for background jobs",
     "keywords": ["silverstripe","redis"],
     "homepage": "http://github.com/stojg/silverstripe-resque",
@@ -12,7 +12,7 @@
             "homepage": "https://stojg.se/"
         }
     ],
-	"require": {
-		"chrisboulton/php-resque": "dev-master#b0843f4dba7e914728539c4001b8325b68c44354"
-	}
+    "require": {
+        "resque/php-resque": "~1.3"
+    }
 }


### PR DESCRIPTION
Use the new supported upstream, as chrisboulton/php-resque was abandoned.

No need to peg master anymore as all changes were flushed out to a new release upstream.

Once merged, I'll tag this repo with 1.3 and then upgrade deploynaut to use this new version.